### PR TITLE
Klude Fixed Crash Referenced in Issue 13

### DIFF
--- a/ogmp/Data/Scripts/remote_player.as
+++ b/ogmp/Data/Scripts/remote_player.as
@@ -486,4 +486,7 @@ int GetRightFootPlanted(){
     }else{
         return 0;
     }
+
+void BrainSpeciesUpdate() {}
+
 }


### PR DESCRIPTION
Just adding an empty function for BrainSpeciesUpdate() lets you join servers (where previously I experienced the crash referenced here https://github.com/ogmp/ogmp_client/issues/13)